### PR TITLE
Surface Laptop 4 interl 13" support

### DIFF
--- a/module/dkms.conf
+++ b/module/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="surface_gpe"
-PACKAGE_VERSION="0.1"
+PACKAGE_VERSION="0.2"
 CLEAN="make clean"
 MAKE[0]="make all KVERSION=$kernelver"
 BUILT_MODULE_NAME[0]="surface_gpe"

--- a/module/surface_gpe.c
+++ b/module/surface_gpe.c
@@ -164,6 +164,18 @@ static const struct dmi_system_id dmi_lid_device_table[] = {
 		.driver_data = (void *)lid_device_props_l4D,
 	},
 	{
+		.ident = "Surface Laptop 4 (Intel 13\")",
+		.matches = {
+			/*
+			 * We match for SKU here due to different variants: The
+			 * AMD (15") version does not rely on GPEs.
+			 */
+			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "Surface_Laptop_4_1950:1951"),
+		},
+		.driver_data = (void *)lid_device_props_l4B,
+	},
+	{
 		.ident = "Surface Laptop Studio",
 		.matches = {
 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),


### PR DESCRIPTION
Dear qzed,

I've modified the module to support Surface Laptop 4 Interl 13" version.
I am using it in the last few weeks and seems to be working.

Thanks for your module !

Kind regards,

pcsabi